### PR TITLE
Add ChatGPT converter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Claude History Converter
+# AI Conversation History Converter
 
 ![Obsidian Graph View of Claude Conversations](claude-data-graph.png)
 
-Convert your Claude conversation history into an organized, searchable collection of markdown files.
+Convert your AI conversation history (Claude or ChatGPT) into an organized, searchable collection of markdown files.
 
 ## Features
 
@@ -16,6 +16,8 @@ Convert your Claude conversation history into an organized, searchable collectio
 - 🏷️ **Tag & File Pattern Analysis** - Interactive configuration for graph visualization
 
 ## Quick Start
+
+### For Claude Users
 
 1. **Export your Claude data**
    - Go to https://claude.ai/settings
@@ -43,7 +45,34 @@ Convert your Claude conversation history into an organized, searchable collectio
    ./convert_claude_history.sh my_claude_archive
    ```
 
-The script will guide you through an interactive process to configure your conversion.
+### For ChatGPT Users
+
+1. **Export your ChatGPT data**
+   - Go to https://chatgpt.com/gpts/mine
+   - Click on your profile → Data controls → Export data
+   - Download and extract the ZIP file
+
+2. **Clone this repository**
+   ```bash
+   git clone https://github.com/aaronsb/claude-knowledge-converter.git
+   cd claude-knowledge-converter
+   ```
+
+3. **Copy your ChatGPT conversations.json to the input directory**
+   ```bash
+   cp ~/Downloads/conversations.json input/
+   ```
+
+4. **Run the ChatGPT converter**
+   ```bash
+   # Show help and usage information
+   ./convert_chatgpt_history.sh
+   
+   # Convert with a custom directory name
+   ./convert_chatgpt_history.sh my_chatgpt_archive
+   ```
+
+Both converters will guide you through an interactive process to configure your conversion.
 
 ## Interactive Walkthrough
 
@@ -149,16 +178,19 @@ The default of 30 captures the "head" of the distribution - the tags that appear
 
 ```
 claude-knowledge-converter/
-├── convert_claude_history.sh    # Main conversion script
+├── convert_claude_history.sh    # Claude conversion script
+├── convert_chatgpt_history.sh   # ChatGPT conversion script
 ├── README.md                    # This file
-├── input/                       # Place your Claude export files here
-│   ├── conversations.json
-│   ├── projects.json
-│   └── users.json
+├── input/                       # Place your export files here
+│   ├── conversations.json       # From Claude or ChatGPT
+│   ├── projects.json           # Claude only
+│   └── users.json              # Claude only
 ├── output/                      # Converted files will appear here
-│   └── claude_history/          # Your conversion output
+│   └── your_output_name/        # Your conversion output
 └── src/                         # Source code
-    ├── convert_enhanced.py      # The conversion engine
+    ├── convert_enhanced.py      # Claude conversion engine
+    ├── convert_chatgpt.py       # ChatGPT conversion engine
+    ├── converter_base.py        # Shared converter functionality
     ├── tag_analyzer.py          # Tag and file pattern analysis
     ├── color_previews.py        # ANSI color scheme previews
     ├── analyze_tags.py          # Comprehensive tag analysis tool
@@ -168,8 +200,10 @@ claude-knowledge-converter/
 
 ## What You Get
 
+Both Claude and ChatGPT converters produce the same output structure for compatibility:
+
 ```
-output/claude_history/
+output/your_output_name/
 ├── conversations/
 │   └── 2024/
 │       └── 03-March/

--- a/convert_chatgpt_history.sh
+++ b/convert_chatgpt_history.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# ChatGPT History Converter
+# Converts ChatGPT conversation exports to organized markdown files
+
+set -e  # Exit on error
+
+echo "==================================="
+echo "ChatGPT History Converter"
+echo "==================================="
+echo ""
+
+# If no arguments provided, show help
+if [ $# -eq 0 ]; then
+    echo "This tool converts your ChatGPT conversation export into organized markdown files."
+    echo ""
+    echo "What it does:"
+    echo "  • Organizes conversations by date (year/month/day folders)"
+    echo "  • Extracts markdown content into .md files with contextual titles"
+    echo "  • Generates keyword hashtags using TF-IDF analysis"
+    echo "  • Extracts code blocks into separate files"
+    echo "  • Creates searchable JSON index files"
+    echo ""
+    echo "Usage:"
+    echo "  ./convert_chatgpt_history.sh <output_directory>"
+    echo ""
+    echo "Example:"
+    echo "  ./convert_chatgpt_history.sh chatgpt_history"
+    echo "  ./convert_chatgpt_history.sh my_chatgpt_archive"
+    echo ""
+    echo "Before running, ensure you have extracted your ChatGPT export"
+    echo "and placed conversations.json in the input/ directory."
+    echo ""
+    exit 0
+fi
+
+OUTPUT_DIR="$1"
+
+# Check if required JSON file exists in input directory
+if [ ! -f "input/conversations.json" ]; then
+    echo "ERROR: ChatGPT conversations.json not found in input/ directory!"
+    echo ""
+    echo "Please extract your ChatGPT export and place the following file:"
+    echo "  - input/conversations.json"
+    echo ""
+    echo "You can export your ChatGPT data from: https://chatgpt.com/gpts/mine (Data Controls)"
+    exit 1
+fi
+
+# Show what will be processed
+echo "Found export file:"
+echo "  ✓ input/conversations.json ($(ls -lh input/conversations.json | awk '{print $5}'))"
+echo ""
+echo "Output will be saved to: output/$OUTPUT_DIR/"
+echo ""
+
+# Check if output directory already exists
+if [ -d "output/$OUTPUT_DIR" ]; then
+    echo "WARNING: Output directory 'output/$OUTPUT_DIR' already exists!"
+    echo "Running this script will DELETE the existing directory and create a new one."
+    echo ""
+fi
+
+# Ask for confirmation before proceeding
+echo "This will:"
+echo "  1. Set up a Python virtual environment (if needed)"
+echo "  2. Install required dependencies"
+echo "  3. Process your ChatGPT conversations.json from input/"
+echo "  4. Create organized markdown files in 'output/$OUTPUT_DIR/'"
+echo ""
+read -p "Do you want to proceed? (y/N): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Conversion cancelled."
+    exit 0
+fi
+
+# Remove existing directory if it exists
+if [ -d "output/$OUTPUT_DIR" ]; then
+    echo "Removing existing output directory..."
+    rm -rf "output/$OUTPUT_DIR"
+fi
+
+# Check if virtual environment exists
+if [ ! -d "venv" ]; then
+    echo "Creating Python virtual environment..."
+    python3 -m venv venv
+fi
+
+# Activate virtual environment and install dependencies
+echo "Installing dependencies..."
+source venv/bin/activate
+
+# Install required packages
+pip install --quiet --upgrade pip
+pip install --quiet ijson scikit-learn nltk
+
+# Download NLTK data
+echo "Downloading language processing data..."
+python -c "import nltk; nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('stopwords', quiet=True)" 2>/dev/null
+
+# Check if converter script exists
+if [ ! -f "src/convert_chatgpt.py" ]; then
+    echo "ERROR: src/convert_chatgpt.py not found!"
+    echo "Please ensure the converter script is in the src/ directory."
+    exit 1
+fi
+
+# Run the conversion
+echo ""
+echo "Starting conversion..."
+echo "This may take a few minutes depending on the size of your history."
+echo ""
+
+python src/convert_chatgpt.py "input/conversations.json" "output/$OUTPUT_DIR"
+
+echo ""
+echo "==================================="
+echo "Conversion complete!"
+echo ""
+echo "Your converted history is in: output/$OUTPUT_DIR/"
+echo ""
+echo "Features included:"
+echo "  ✓ Conversations organized by date (year/month/day)"
+echo "  ✓ Markdown files with full conversation context in titles"
+echo "  ✓ Automatic keyword extraction and hashtags"
+echo "  ✓ Code blocks extracted to separate files"
+echo "  ✓ Searchable index files with keywords"
+echo ""
+echo "To use with Obsidian:"
+echo "  1. Open Obsidian"
+echo "  2. Click 'Open folder as vault'"
+echo "  3. Select: output/$OUTPUT_DIR/"
+echo ""
+echo "Happy exploring your ChatGPT history!"
+echo "==================================="

--- a/src/convert_chatgpt.py
+++ b/src/convert_chatgpt.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+ChatGPT conversation converter that outputs the same format as Claude converter.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+import ijson
+import re
+from typing import Dict, Any, List, Tuple, Optional, Set
+from decimal import Decimal
+from collections import Counter, defaultdict
+import math
+import string
+import nltk
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
+
+# Import shared components from Claude converter
+from convert_enhanced import KeywordExtractor
+from tag_analyzer import TagAnalyzer
+from converter_base import (
+    DecimalEncoder, create_conversation_structure, detect_markdown,
+    extract_code_snippets, enhance_markdown_content, save_message_files
+)
+
+class ChatGPTConverter:
+    """Convert ChatGPT export to Claude converter format"""
+    
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+        self.keyword_extractor = KeywordExtractor()
+        self.tag_analyzer = None  # Will be initialized later if needed
+        
+    def parse_export(self, file_path: Path) -> List[Dict[str, Any]]:
+        """Parse ChatGPT conversations.json and convert to Claude format"""
+        conversations = []
+        
+        with open(file_path, 'rb') as file:
+            parser = ijson.items(file, 'item')
+            
+            for conv_data in parser:
+                try:
+                    conversation = self._convert_conversation(conv_data)
+                    if conversation:
+                        conversations.append(conversation)
+                except Exception as e:
+                    print(f"Error parsing conversation: {e}")
+                    continue
+        
+        return conversations
+    
+    def _convert_conversation(self, conv_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Convert ChatGPT conversation to Claude format"""
+        # Extract basic metadata
+        conv_id = conv_data.get('id', conv_data.get('conversation_id', ''))
+        if not conv_id:
+            # Generate a UUID-like ID if missing
+            import uuid
+            conv_id = str(uuid.uuid4())
+            
+        title = conv_data.get('title', 'Untitled Conversation')
+        
+        # Convert timestamps
+        created_at = datetime.fromtimestamp(float(conv_data.get('create_time', 0))).isoformat() + 'Z'
+        updated_at = datetime.fromtimestamp(float(conv_data.get('update_time', 0))).isoformat() + 'Z'
+        
+        # Extract messages from the mapping structure
+        mapping = conv_data.get('mapping', {})
+        chat_messages = self._extract_messages_from_mapping(mapping)
+        
+        if not chat_messages:
+            return None
+        
+        # Create Claude-compatible conversation structure
+        conversation = {
+            'uuid': conv_id,
+            'name': title,
+            'created_at': created_at,
+            'updated_at': updated_at,
+            'account': {
+                'uuid': 'chatgpt-account'  # Placeholder since ChatGPT doesn't have account UUIDs
+            },
+            'chat_messages': chat_messages
+        }
+        
+        return conversation
+    
+    def _extract_messages_from_mapping(self, mapping: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Extract messages in Claude format from ChatGPT's mapping structure"""
+        messages = []
+        
+        # Find the root node
+        root_nodes = []
+        for node_id, node in mapping.items():
+            parent = node.get('parent')
+            if parent is None or parent == 'client-created-root':
+                root_nodes.append(node_id)
+        
+        # Traverse the tree from each root
+        for root_id in root_nodes:
+            self._traverse_message_tree(mapping, root_id, messages)
+        
+        # Sort messages by timestamp
+        messages.sort(key=lambda m: m.get('created_at', ''))
+        
+        return messages
+    
+    def _traverse_message_tree(self, mapping: Dict[str, Any], node_id: str, 
+                               messages: List[Dict[str, Any]], visited: set = None):
+        """Recursively traverse the message tree"""
+        if visited is None:
+            visited = set()
+        
+        if node_id in visited or node_id not in mapping:
+            return
+        
+        visited.add(node_id)
+        node = mapping[node_id]
+        
+        # Extract message if present
+        if 'message' in node and node['message']:
+            msg_data = node['message']
+            message = self._parse_message(msg_data)
+            if message and message.get('text'):  # Only add non-empty messages
+                messages.append(message)
+        
+        # Traverse children
+        children = node.get('children', [])
+        for child_id in children:
+            self._traverse_message_tree(mapping, child_id, messages, visited)
+    
+    def _parse_message(self, msg_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Parse a single message to Claude format"""
+        # Extract author info
+        author = msg_data.get('author', {})
+        role = author.get('role', 'unknown')
+        
+        # Skip system messages that are visually hidden
+        metadata = msg_data.get('metadata', {})
+        if metadata.get('is_visually_hidden_from_conversation'):
+            return None
+        
+        # Map ChatGPT roles to Claude roles
+        sender_map = {
+            'user': 'human',
+            'assistant': 'assistant',
+            'system': 'system',
+            'tool': 'assistant'
+        }
+        sender = sender_map.get(role, role)
+        
+        # Extract content
+        content_data = msg_data.get('content', {})
+        content_parts = content_data.get('parts', [])
+        text = '\n\n'.join(str(part) for part in content_parts if part)
+        
+        # Extract timestamp
+        create_time = msg_data.get('create_time')
+        if create_time:
+            timestamp = datetime.fromtimestamp(float(create_time)).isoformat() + 'Z'
+        else:
+            timestamp = datetime.now().isoformat() + 'Z'
+        
+        # Build Claude-compatible message
+        message = {
+            'uuid': msg_data.get('id', ''),
+            'sender': sender,
+            'created_at': timestamp,
+            'updated_at': timestamp,
+            'text': text,
+            'files': [],
+            'content': []
+        }
+        
+        # Handle attachments if any
+        if 'attachments' in metadata:
+            for att in metadata['attachments']:
+                message['files'].append({
+                    'file_name': att.get('name', 'Unnamed'),
+                    'file_type': att.get('mime_type', 'unknown'),
+                    'file_size': att.get('size', 0)
+                })
+        
+        return message
+    
+    def save_conversation(self, conversation: Dict[str, Any], conv_folder: Path, 
+                         conv_title: str, date_info: Dict[str, str]):
+        """Save conversation using Claude converter format"""
+        # Create a unique conversation tag
+        conv_id = conversation['uuid'][:8] if len(conversation['uuid']) >= 8 else conversation['uuid']
+        conv_tag = f"conv-{conv_title.replace(' ', '-').lower()}-{conv_id}"
+        
+        # Collect all text for keyword extraction
+        all_text = []
+        
+        # Add conversation name
+        if conversation.get('name'):
+            all_text.append(conversation['name'])
+        
+        # Collect message texts
+        for message in conversation.get('chat_messages', []):
+            if message.get('text'):
+                all_text.append(message['text'])
+        
+        # Extract keywords
+        full_text = ' '.join(all_text)
+        conversation_keywords = self.keyword_extractor.extract_keywords(full_text) if full_text else []
+        
+        # Update corpus statistics
+        if full_text:
+            self.keyword_extractor.update_corpus_stats(full_text)
+        
+        # Save metadata
+        metadata = {
+            'uuid': conversation['uuid'],
+            'name': conversation.get('name', ''),
+            'created_at': conversation['created_at'],
+            'updated_at': conversation['updated_at'],
+            'account_uuid': conversation['account']['uuid'],
+            'message_count': len(conversation.get('chat_messages', [])),
+            'has_markdown_content': False,
+            'keywords': conversation_keywords,
+            'source': 'chatgpt'  # Add source indicator
+        }
+        
+        # Save messages
+        messages_folder = conv_folder / 'messages'
+        messages_folder.mkdir(exist_ok=True)
+        
+        markdown_files = []
+        
+        for idx, message in enumerate(conversation.get('chat_messages', [])):
+            # Use shared save_message_files function
+            result = save_message_files(
+                message, idx, messages_folder, conv_folder,
+                conv_title, date_info, conv_tag, conversation_keywords,
+                platform='ChatGPT'
+            )
+            
+            if result['has_markdown']:
+                metadata['has_markdown_content'] = True
+                if result['markdown_file']:
+                    markdown_files.append(result['markdown_file'])
+        
+        # Update metadata with markdown files
+        if markdown_files:
+            metadata['markdown_files'] = markdown_files
+        
+        # Save conversation metadata
+        metadata_path = conv_folder / 'metadata.json'
+        with open(metadata_path, 'w', encoding='utf-8') as f:
+            json.dump(metadata, f, indent=2, ensure_ascii=False, cls=DecimalEncoder)
+        
+        # Update tag analyzer if available
+        if self.tag_analyzer:
+            self.tag_analyzer.add_tag(conv_tag, 'conversation')
+            for keyword in conversation_keywords:
+                self.tag_analyzer.add_tag(keyword, 'keyword')
+    
+    def convert(self, input_file: Path):
+        """Main conversion method"""
+        print(f"Converting ChatGPT export: {input_file}")
+        
+        # Parse conversations
+        conversations = self.parse_export(input_file)
+        print(f"Found {len(conversations)} conversations")
+        
+        # Create output structure
+        conv_output_dir = self.output_dir / 'conversations'
+        conv_output_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Process each conversation
+        conversation_index = []
+        
+        for conversation in conversations:
+            try:
+                # Get date info
+                created_at = datetime.fromisoformat(conversation['created_at'].replace('Z', '+00:00'))
+                date_info = {
+                    'year': created_at.strftime('%Y'),
+                    'month': created_at.strftime('%m'),
+                    'month_name': created_at.strftime('%B'),
+                    'day': created_at.strftime('%d')
+                }
+                
+                # Create conversation folder
+                conv_title = conversation['name'].replace('_', ' ')
+                conv_id = conversation['uuid'][:8] if len(conversation['uuid']) >= 8 else conversation['uuid']
+                conv_folder_name = f"{conv_title.replace(' ', '_')}_{conv_id}"
+                
+                conv_folder = create_conversation_structure(
+                    conv_output_dir,
+                    date_info,
+                    conv_folder_name
+                )
+                
+                # Save conversation
+                self.save_conversation(conversation, conv_folder, conv_title, date_info)
+                
+                # Add to index
+                relative_path = f"{date_info['year']}/{date_info['month']}-{date_info['month_name']}/{date_info['day']}/{conv_folder_name}"
+                index_entry = {
+                    'path': relative_path,
+                    'uuid': conversation['uuid'],
+                    'name': conversation['name'],
+                    'created_at': conversation['created_at'],
+                    'message_count': len(conversation.get('chat_messages', [])),
+                    'has_markdown': any('markdown_file' in msg for msg in conversation.get('chat_messages', [])),
+                    'keywords': self.keyword_extractor.extract_keywords(' '.join([
+                        conversation.get('name', ''),
+                        ' '.join(msg.get('text', '') for msg in conversation.get('chat_messages', []))
+                    ])),
+                    'source': 'chatgpt'
+                }
+                conversation_index.append(index_entry)
+                
+            except Exception as e:
+                print(f"Error processing conversation {conversation.get('name', 'Unknown')}: {e}")
+                continue
+        
+        # Save conversation index
+        index_path = self.output_dir / 'conversations_index.json'
+        with open(index_path, 'w', encoding='utf-8') as f:
+            json.dump(conversation_index, f, indent=2, ensure_ascii=False, cls=DecimalEncoder)
+        
+        # Save conversion summary
+        summary = {
+            'created_at': datetime.now().isoformat() + 'Z',
+            'source_files': {
+                'conversations.json': True
+            },
+            'output_structure': {
+                'conversations': f"{self.output_dir}/conversations/{{year}}/{{month}}/{{day}}/{{conversation_name}}/",
+                'indexes': ['conversations_index.json'],
+                'markdown_extraction': True,
+                'code_snippet_extraction': True,
+                'keyword_extraction': True
+            },
+            'features': [
+                'ChatGPT to Claude format conversion',
+                'Enhanced markdown titles with full conversation context',
+                'Automatic keyword extraction and hashtag generation',
+                'Human-readable titles throughout',
+                'Markdown files saved as .md with proper headers',
+                'Code blocks extracted to separate files',
+                'Keywords indexed for discovery and search'
+            ],
+            'statistics': {
+                'total_conversations': len(conversations),
+                'conversations_with_markdown': sum(1 for c in conversation_index if c['has_markdown']),
+                'total_keywords': len(set(kw for c in conversation_index for kw in c.get('keywords', [])))
+            }
+        }
+        
+        summary_path = self.output_dir / 'conversion_summary.json'
+        with open(summary_path, 'w', encoding='utf-8') as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False, cls=DecimalEncoder)
+        
+        print(f"\nConversion complete!")
+        print(f"Output directory: {self.output_dir}")
+        print(f"Total conversations: {len(conversations)}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python convert_chatgpt.py <path_to_conversations.json> [output_dir]")
+        sys.exit(1)
+    
+    input_file = Path(sys.argv[1])
+    if not input_file.exists():
+        print(f"Error: Input file '{input_file}' not found")
+        sys.exit(1)
+    
+    # Set output directory
+    if len(sys.argv) >= 3:
+        output_dir = Path(sys.argv[2])
+    else:
+        output_dir = Path('claude_history_enhanced')
+    
+    # Create converter and run
+    converter = ChatGPTConverter(output_dir)
+    converter.convert(input_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/convert_chatgpt.py
+++ b/src/convert_chatgpt.py
@@ -33,7 +33,7 @@ class ChatGPTConverter:
     def __init__(self, output_dir: Path):
         self.output_dir = output_dir
         self.keyword_extractor = KeywordExtractor()
-        self.tag_analyzer = None  # Will be initialized later if needed
+        self.tag_analyzer = TagAnalyzer()  # Initialize for tag analysis
         
     def parse_export(self, file_path: Path) -> List[Dict[str, Any]]:
         """Parse ChatGPT conversations.json and convert to Claude format"""
@@ -363,6 +363,31 @@ class ChatGPTConverter:
         print(f"\nConversion complete!")
         print(f"Output directory: {self.output_dir}")
         print(f"Total conversations: {len(conversations)}")
+        
+        # Run tag analysis and generate Obsidian config
+        print("\n" + "="*60)
+        print("Generating Obsidian graph configuration...")
+        print("="*60)
+        
+        # Scan all markdown files for complete tag analysis
+        self.tag_analyzer.scan_markdown_files_for_tags(self.output_dir)
+        
+        # Interactive water level adjustment for both tags and file patterns
+        tag_water_level, file_water_level, tag_color_scheme, file_color_scheme = self.tag_analyzer.interactive_water_level_adjustment()
+        
+        # Generate Obsidian config files with dual grouping
+        print("\nCreating Obsidian configuration with dual-layer grouping...")
+        print(f"Using {tag_color_scheme} colors for tags and {file_color_scheme} colors for file patterns")
+        self.tag_analyzer.create_obsidian_config(self.output_dir, tag_water_level, file_water_level, 
+                                              tag_color_scheme, file_color_scheme)
+        
+        # Save analysis report
+        report_file = self.tag_analyzer.save_analysis_report(self.output_dir, tag_water_level, file_water_level,
+                                                           tag_color_scheme, file_color_scheme)
+        print(f"Tag analysis report saved to: {report_file}")
+        
+        print("\n" + "="*60)
+        print("CONVERSION COMPLETE!")
 
 
 def main():

--- a/src/converter_base.py
+++ b/src/converter_base.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Base converter functionality shared between Claude and ChatGPT converters.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Any, List, Tuple, Optional
+from datetime import datetime
+from decimal import Decimal
+
+class DecimalEncoder(json.JSONEncoder):
+    """Handle Decimal types in JSON serialization"""
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return super().default(obj)
+
+
+def create_conversation_structure(base_path: Path, date_info: Dict[str, str], 
+                                conversation_name: str) -> Path:
+    """Create the folder structure for a conversation"""
+    # Create year/month/day structure
+    year_folder = base_path / date_info['year']
+    month_folder = year_folder / f"{date_info['month']}-{date_info['month_name']}"
+    day_folder = month_folder / date_info['day']
+    conv_folder = day_folder / conversation_name
+    
+    # Create all directories
+    conv_folder.mkdir(parents=True, exist_ok=True)
+    
+    return conv_folder
+
+
+def detect_markdown(text: str) -> bool:
+    """Detect if text contains markdown formatting"""
+    if not text:
+        return False
+    
+    markdown_patterns = [
+        r'^#{1,6}\s+',  # Headers
+        r'```[\s\S]*?```',  # Code blocks
+        r'`[^`]+`',  # Inline code
+        r'\*\*[^*]+\*\*',  # Bold
+        r'\*[^*]+\*',  # Italic
+        r'\[[^\]]+\]\([^)]+\)',  # Links
+        r'^\s*[-*+]\s+',  # Lists
+        r'^\s*\d+\.\s+',  # Numbered lists
+        r'^\s*>\s+',  # Blockquotes
+        r'^\|.*\|$',  # Tables
+    ]
+    
+    for pattern in markdown_patterns:
+        if re.search(pattern, text, re.MULTILINE):
+            return True
+    
+    return False
+
+
+def extract_code_snippets(text: str, output_folder: Path) -> List[Dict[str, str]]:
+    """Extract code blocks from text and save as separate files"""
+    code_pattern = r'```(\w+)?\n(.*?)```'
+    code_blocks = re.findall(code_pattern, text, re.DOTALL)
+    
+    if not code_blocks:
+        return []
+    
+    snippets_folder = output_folder / 'code_snippets'
+    snippets_folder.mkdir(exist_ok=True)
+    
+    # Language to extension mapping
+    lang_extensions = {
+        'python': 'py',
+        'javascript': 'js',
+        'typescript': 'ts',
+        'java': 'java',
+        'cpp': 'cpp',
+        'c': 'c',
+        'html': 'html',
+        'css': 'css',
+        'sql': 'sql',
+        'bash': 'sh',
+        'shell': 'sh',
+        'json': 'json',
+        'yaml': 'yaml',
+        'xml': 'xml',
+        'markdown': 'md',
+    }
+    
+    saved_snippets = []
+    
+    for idx, (lang, code) in enumerate(code_blocks):
+        lang = lang.lower() if lang else 'txt'
+        extension = lang_extensions.get(lang, lang if lang else 'txt')
+        
+        snippet_filename = f"snippet_{idx:02d}.{extension}"
+        snippet_path = snippets_folder / snippet_filename
+        
+        snippet_path.write_text(code.strip(), encoding='utf-8')
+        
+        saved_snippets.append({
+            'filename': snippet_filename,
+            'language': lang,
+            'size': len(code.strip())
+        })
+    
+    return saved_snippets
+
+
+def enhance_markdown_content(content: str, conv_title: str, msg_idx: int,
+                           sender: str, date_info: Dict[str, str], 
+                           conv_tag: str, keywords: List[str],
+                           platform: str = "Unknown") -> str:
+    """Enhance markdown content with title and metadata"""
+    lines = []
+    
+    # Add title
+    sender_title = sender.replace('_', ' ').title()
+    lines.append(f"# {conv_title} - {msg_idx:03d} {sender_title} Message")
+    lines.append("")
+    
+    # Add original content
+    lines.append(content)
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    
+    # Add hashtags
+    hashtags = [f"#{conv_tag}"]
+    hashtags.extend(f"#{keyword.replace(' ', '-')}" for keyword in keywords)
+    lines.append(' '.join(hashtags))
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    
+    # Add metadata table
+    lines.append("| Field | Value |")
+    lines.append("|-------|-------|")
+    lines.append(f"| Date | {date_info['year']}-{date_info['month_name']}-{date_info['day']} |")
+    lines.append(f"| Conversation ID | {conv_tag.split('-')[-1]} |")
+    lines.append(f"| Platform | {platform} |")
+    
+    return '\n'.join(lines)
+
+
+def save_message_files(message: Dict[str, Any], idx: int, messages_folder: Path,
+                      conv_folder: Path, conv_title: str, date_info: Dict[str, str],
+                      conv_tag: str, keywords: List[str], platform: str = "Unknown") -> Dict[str, Any]:
+    """Save message JSON and extract markdown/code if present"""
+    msg_id = message['uuid'][:8] if len(message.get('uuid', '')) >= 8 else f"{idx:04d}"
+    msg_filename = f"{idx:03d}_{message['sender']}_{msg_id}.json"
+    
+    # Check for markdown content
+    has_markdown = detect_markdown(message.get('text', ''))
+    
+    # Create message metadata
+    msg_metadata = {
+        'uuid': message.get('uuid', ''),
+        'sender': message['sender'],
+        'created_at': message.get('created_at', ''),
+        'updated_at': message.get('updated_at', ''),
+        'text': message.get('text', ''),
+        'has_attachments': bool(message.get('files')) or bool(message.get('attachments')),
+        'has_files': bool(message.get('files')),
+        'content_count': len(message.get('content', [])),
+        'platform': platform
+    }
+    
+    # Save message JSON
+    msg_path = messages_folder / msg_filename
+    with open(msg_path, 'w', encoding='utf-8') as f:
+        json.dump(msg_metadata, f, indent=2, ensure_ascii=False, cls=DecimalEncoder)
+    
+    markdown_file = None
+    
+    # Extract and save markdown if detected
+    if has_markdown and message.get('text'):
+        md_filename = f"{conv_title.replace(' ', '_')}-{idx:03d}_{message['sender'].title()}_Message.md"
+        md_path = conv_folder / md_filename
+        
+        # Add metadata to markdown
+        markdown_content = enhance_markdown_content(
+            message['text'],
+            conv_title,
+            idx,
+            message['sender'],
+            date_info,
+            conv_tag,
+            keywords,
+            platform
+        )
+        
+        md_path.write_text(markdown_content, encoding='utf-8')
+        markdown_file = md_filename
+        msg_metadata['markdown_file'] = md_filename
+        
+        # Extract code snippets
+        snippets = extract_code_snippets(message['text'], conv_folder)
+        if snippets:
+            msg_metadata['code_snippets'] = snippets
+    
+    # Save updated message metadata if markdown was found
+    if 'markdown_file' in msg_metadata:
+        with open(msg_path, 'w', encoding='utf-8') as f:
+            json.dump(msg_metadata, f, indent=2, ensure_ascii=False, cls=DecimalEncoder)
+    
+    return {
+        'filename': msg_filename,
+        'has_markdown': has_markdown,
+        'markdown_file': markdown_file,
+        'message_metadata': msg_metadata
+    }


### PR DESCRIPTION
## Summary
- Added ChatGPT converter that outputs the same format as Claude converter
- Created shared converter functionality to maximize code reuse
- Maintains full compatibility with existing tag analysis and Obsidian features

## Changes
- **New ChatGPT converter** (`src/convert_chatgpt.py`):
  - Parses ChatGPT's node-based conversation structure
  - Maps ChatGPT roles to Claude format (user→human)
  - Extracts markdown and code snippets
  - Generates same folder structure and metadata format
  
- **Shared converter base** (`src/converter_base.py`):
  - Common folder structure creation
  - Markdown detection and enhancement
  - Code snippet extraction
  - Message file saving
  
- **New wrapper script** (`convert_chatgpt_history.sh`):
  - Uses same venv approach as Claude script
  - Interactive confirmation flow
  - Consistent user experience
  
- **Updated documentation**:
  - README now covers both Claude and ChatGPT
  - Clear instructions for each platform
  - Emphasizes output compatibility

## Test plan
- [ ] Test ChatGPT converter with sample export
- [ ] Verify output structure matches Claude converter
- [ ] Confirm tag analysis works correctly
- [ ] Test Obsidian graph visualization
- [ ] Verify code snippet extraction
- [ ] Check markdown enhancement

🤖 Generated with [Claude Code](https://claude.ai/code)